### PR TITLE
fix: Set default intended direction to forward for low speed

### DIFF
--- a/src/browser/hooks/useBoat/navigation/index.tsx
+++ b/src/browser/hooks/useBoat/navigation/index.tsx
@@ -95,6 +95,9 @@ export const useNavigation = ({
         currentState.intendedDirection = INTENDED_DIRECTION.FORWARD;
       } else if (currentState.speed < -0.001) {
         currentState.intendedDirection = INTENDED_DIRECTION.BACKWARD;
+      } else {
+        // Default to forward if speed is very low but not exactly zero
+        currentState.intendedDirection = INTENDED_DIRECTION.FORWARD; 
       }
     }
 


### PR DESCRIPTION
It feels weird when the boat is not moving and the controls are in reverse after moving backwards, previously the user had to move forwards a bit to reset controls